### PR TITLE
Add recording to FOSDEM talk

### DIFF
--- a/talks.qmd
+++ b/talks.qmd
@@ -16,6 +16,7 @@ listing:
     - title
     - subtitle
     - author
+    - recording
   page-size: 10
   sort: date desc
   type: table

--- a/talks/2026-01-31-unit-testing-in-fortran/index.qmd
+++ b/talks/2026-01-31-unit-testing-in-fortran/index.qmd
@@ -6,6 +6,9 @@ format: revealjs
 subtitle: "FOSDEM 2026: Testing and Continuous Delivery devroom"
 title: Unit testing in Fortran
 logo: /assets/ucl_logo_light.png
+recording:
+  "[Devroom
+  recording](https://mirror.cyberbits.eu/fosdem/2026/h2213/QMWWPB-unit-testing-in-fortran.av1.webm)"
 ---
 
 {{< include _slides/current_state_of_fortran.qmd >}}


### PR DESCRIPTION

- Adds recording for FODEM 2026 talk.
- Adds a `recording` column to the talks table.